### PR TITLE
zdocx_get_types.prog.xml with latest abapGit vers.

### DIFF
--- a/src/zdocx_get_types.prog.xml
+++ b/src/zdocx_get_types.prog.xml
@@ -9,6 +9,31 @@
     <FIXPT>X</FIXPT>
     <UCCHECK>X</UCCHECK>
    </PROGDIR>
+   <TPOOL>
+    <item>
+     <ID>R</ID>
+     <ENTRY>get type definitions from template</ENTRY>
+     <LENGTH>34</LENGTH>
+    </item>
+    <item>
+     <ID>S</ID>
+     <KEY>P_FPATH</KEY>
+     <ENTRY>Path to template.docx</ENTRY>
+     <LENGTH>29</LENGTH>
+    </item>
+    <item>
+     <ID>S</ID>
+     <KEY>P_NORMAL</KEY>
+     <ENTRY>normal coma at end,</ENTRY>
+     <LENGTH>27</LENGTH>
+    </item>
+    <item>
+     <ID>S</ID>
+     <KEY>P_OTHER</KEY>
+     <ENTRY>, coma at begin of definition</ENTRY>
+     <LENGTH>37</LENGTH>
+    </item>
+   </TPOOL>
   </asx:values>
  </asx:abap>
 </abapGit>


### PR DESCRIPTION
Solves minor issue #5 
by simply staging via latest abapGit version 1.94.0
(removes STATE and VARCL from the XML; the texts of the text pool are added)