### PR TITLE
Still problem with STATE and VARCL

### DIFF
--- a/.abapgit.xml
+++ b/.abapgit.xml
@@ -14,6 +14,7 @@
     <item>/.gitlab-ci.yml</item>
     <item>/abaplint.json</item>
     <item>/azure-pipelines.yml</item>
+    <item>/zcl_docx_v3.zip</item>
    </IGNORE>
   </DATA>
  </asx:values>

--- a/src/zdocx_get_types.prog.xml
+++ b/src/zdocx_get_types.prog.xml
@@ -4,8 +4,6 @@
   <asx:values>
    <PROGDIR>
     <NAME>ZDOCX_GET_TYPES</NAME>
-    <STATE>A</STATE>
-    <VARCL>X</VARCL>
     <SUBC>1</SUBC>
     <RLOAD>E</RLOAD>
     <FIXPT>X</FIXPT>


### PR DESCRIPTION
Solves minor issue #5
by simply staging via latest abapGit version 1.94.0
(removes STATE and VARCL from the XML)
+ "zcl_docx_v3.zip" added to "files to be ignored" in abapgit.xml
